### PR TITLE
Use https for guids, links and image sources

### DIFF
--- a/dilbert.py
+++ b/dilbert.py
@@ -8,6 +8,7 @@ http://github.com/fredley/dilbert-rss
 """
 
 import urllib2, datetime, sys, re
+from urlparse import urljoin
 import PyRSS2Gen
 from BeautifulSoup import BeautifulSoup
 
@@ -16,7 +17,7 @@ def getDetails(url, baseURL):
     soup = BeautifulSoup(page)
     date = soup.findAll('date')[0].text
     pubDate = datetime.datetime.strptime(date, "%A %B %d,%Y")
-    img = soup.findAll('div', {'class': 'img-comic-container' })[0].find('img')['src']
+    img = urljoin(baseURL, soup.findAll('div', {'class': 'img-comic-container' })[0].find('img')['src'])
 
     results = {}
     results['item'] = PyRSS2Gen.RSSItem(
@@ -29,21 +30,21 @@ def getDetails(url, baseURL):
     results['prev_href'] = soup.findAll('div', {'class': re.compile('nav-left')})[0].find('a')['href']
     return results
 
-url = 'http://dilbert.com'
+url = 'https://dilbert.com'
 page = urllib2.urlopen(url).read()
 soup = BeautifulSoup(page)
-nextUrl = soup.findAll('div', {'class': re.compile('comic-item-container') })[0].find('a')['href']
+nextUrl = urljoin(url, soup.findAll('div', {'class': re.compile('comic-item-container') })[0].find('a')['href'])
 strips = []
 
 for i in range(0,10):
     details = getDetails(nextUrl,url)
     strips.append(details['item'])
-    nextUrl = url + details['prev_href']
+    nextUrl = urljoin(url, details['prev_href'])
 
 # Construct RSS
 rss = PyRSS2Gen.RSS2(
     title = "Dilbert Daily Strip",
-    link = "http://dilbert.com",
+    link = url,
     description = "An unofficial RSS feed for dilbert.com.",
     lastBuildDate = datetime.datetime.now(),
     items = strips)


### PR DESCRIPTION
The dilbert.com site now uses https (redirecting http requests). The comic link used to determine the URL of today's strip is a full https URL. The nav-left links used to find links to strips from previous days are relative.

The output will therefore contain https guids and links for today's strip, but http guids and links for previous days (see the example below). This results in duplicate items when processed by an RSS reader.

```xml
<?xml version="1.0" encoding="iso-8859-1"?>
<rss version="2.0">
  <channel>
    <title>Dilbert Daily Strip</title>
    <link>http://dilbert.com</link>
    <description>An unofficial RSS feed for dilbert.com.</description>
    <lastBuildDate>Mon, 21 Oct 2019 20:27:40 GMT</lastBuildDate>
    <generator>PyRSS2Gen-1.1.0</generator>
    <docs>http://blogs.law.harvard.edu/tech/rss</docs>
    <item>
      <title>Dilbert comic for October 21, 2019</title>
      <link>https://dilbert.com/strip/2019-10-21</link>
      <description>&lt;a href='https://dilbert.com/strip/2019-10-21'&gt;&lt;img src='//assets.amuniversal.com/84f1bdb0c7460137c2df005056a9545d' /&gt;&lt;/a&gt;</description>
      <guid isPermaLink="true">https://dilbert.com/strip/2019-10-21</guid>
      <pubDate>Mon, 21 Oct 2019 00:00:00 GMT</pubDate>
    </item>
    <item>
      <title>Dilbert comic for October 20, 2019</title>
      <link>http://dilbert.com/strip/2019-10-20</link>
      <description>&lt;a href='http://dilbert.com/strip/2019-10-20'&gt;&lt;img src='//assets.amuniversal.com/bf2ac5c0b0d30137ba71005056a9545d' /&gt;&lt;/a&gt;</description>
      <guid isPermaLink="true">http://dilbert.com/strip/2019-10-20</guid>
      <pubDate>Sun, 20 Oct 2019 00:00:00 GMT</pubDate>
    </item>    
  </channel>
</rss>
```

This pull request changes the script to convert all URLs found to full https URLs (including the protocol-relative URLs used for the images, resolving #7).